### PR TITLE
add wheel to build, include a requirements_dev.txt and document

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black pyflakes mypy
+          pip install -r requirements_dev.txt
       - name: Check black formatter and pyflakes
         run: |
           black forestplot/ --check -l 95
@@ -36,8 +36,7 @@ jobs:
           mypy
       - name: Generate coverage report
         run: |
-          pip install pytest coverage
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi        
+          if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
           coverage run -m pytest
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v2          
@@ -58,8 +57,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
     - name: Test with pytest
       run: |
         pytest -v --disable-warnings
@@ -80,8 +78,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
     - name: Test with pytest
       run: |
         pytest -v --disable-warnings
@@ -102,8 +99,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        pip install -r requirements.txt
+        if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
     - name: Test with pytest
       run: |
         pytest -v --disable-warnings

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,6 @@ jobs:
           mypy
       - name: Generate coverage report
         run: |
-          if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
           coverage run -m pytest
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v2          
@@ -57,7 +56,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
+        pip install -r requirements_dev.txt
     - name: Test with pytest
       run: |
         pytest -v --disable-warnings
@@ -78,7 +77,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
+        pip install -r requirements_dev.txt
     - name: Test with pytest
       run: |
         pytest -v --disable-warnings
@@ -99,7 +98,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
+        pip install -r requirements_dev.txt
     - name: Test with pytest
       run: |
         pytest -v --disable-warnings

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ prepack:
 	@echo "+ $@"
 	@rm -rf dist/ forestplot.egg-info/
 	@rm -rf dist/ pyforestplot.egg-info/
-	@python setup.py sdist
+	@python setup.py sdist bdist_wheel
 	twine check dist/*
 
 PACKAGE_FILES := build/ dist/ *.egg-info/ *.egg-info *.egg

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ git clone https://github.com/LSYS/forestplot.git
 cd forestplot
 pip install .
 ```
+
+Developer installation<br>
+```bash
+git clone https://github.com/LSYS/forestplot.git
+cd forestplot
+pip install -r requirements_dev.txt
+
+make lint
+make test
+```
+
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,16 @@
+-r requirements.txt
+
+# build
+wheel
+
+# test
+coverage
+pytest
+
+# lint
+black
+flake8
+mypy
+
+# package in local install
+-e .


### PR DESCRIPTION
Add a wheel to the build command so that that [pypi](https://pypi.org/project/forestplot/#files) will have a wheel instead of just a source package; fixes https://github.com/LSYS/forestplot/issues/32.

To build a wheel, I needed to pip install the [wheel](https://pypi.org/project/wheel/) package, but didn't find a consistent place to put this. Therefore, I added a `requirements_dev.txt` file and documented its use. Its more than you were asking for with this PR, but I think it'll make it easy to more consistently add developer requirements.